### PR TITLE
fixup! syntax formating with clang and costexpr allcaps

### DIFF
--- a/src/LATBOLTZ/fix_lb_multicomponent.h
+++ b/src/LATBOLTZ/fix_lb_multicomponent.h
@@ -19,7 +19,7 @@
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
-FixStyle(lb / multicomponent, FixLbMulticomponent)
+FixStyle(lb/multicomponent, FixLbMulticomponent)
 #else
 
 #ifndef LMP_FIX_LB_MULTICOMPONENT_H


### PR DESCRIPTION
Remove extra spaces from fix name in header file.